### PR TITLE
Add OdooRecordset and integrate into API

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ outside an Odoo environment.
 
 - 🔐 Simple session-based authentication
 - 🌐 `OdooSession` — mirrors `self.env` in Odoo
+- 📋 `OdooRecordset` — Odoo-style recordsets with `ids`, `mapped`, `filtered`, `sorted`, `ensure_one`, set operations
 - 📝 Direct access to all Odoo model methods
 - 🔍 `search`, `search_read`, `search_count`, `read`, `browse`
 - ✏️ `create`, `write`, `unlink`
@@ -67,12 +68,17 @@ Partner = env['res.partner']
 ### Search for records
 
 ```python
-# Returns a list of OdooRecord objects
+# Returns an OdooRecordset — iterate, index, check len, etc.
 partners = Partner.search([('is_company', '=', True)], limit=10)
 
 for partner in partners:
     print(partner.name)   # field values are fetched lazily and cached
     print(partner.email)
+
+# Singleton field delegation — access fields directly on a single-record set
+partner = Partner.search([('name', '=', 'John')], limit=1)
+if partner:               # falsy when empty
+    print(partner.name)   # field delegation on single-record set
 ```
 
 ### Search and read (returns dicts)
@@ -126,8 +132,31 @@ Partner.unlink([4, 5, 6])
 ### Browse by ID
 
 ```python
-partner = Partner.browse(1)          # single OdooRecord
-partners = Partner.browse([1, 2, 3]) # list of OdooRecord
+partner = Partner.browse(1)          # single-record OdooRecordset
+partners = Partner.browse([1, 2, 3]) # multi-record OdooRecordset
+print(partners.ids)                  # [1, 2, 3]
+```
+
+### Recordset helpers
+
+```python
+# mapped — collect field values across all records
+names = partners.mapped('name')      # ['Alice', 'Bob', 'Charlie']
+
+# filtered — keep records matching a condition
+companies = partners.filtered(lambda r: r.is_company)
+
+# sorted — sort by field or key
+by_name = partners.sorted('name')
+by_id_desc = partners.sorted(reverse=True)
+
+# ensure_one — raise ValueError if not exactly one record
+partner = partners.filtered(lambda r: r.id == 1).ensure_one()
+
+# set operations
+all_partners = partners1 | partners2   # union (deduplicated)
+common = partners1 & partners2         # intersection
+diff = partners1 - partners2           # difference
 ```
 
 ### Read raw data
@@ -282,6 +311,25 @@ except OdooException as e:
 ```
 
 ---
+
+## What's New in Version 0.3.1
+
+- **`OdooRecordset`** — new class mirroring Odoo's native recordset API;
+  `search()`, `browse()`, and `create()` now return `OdooRecordset` instead
+  of plain lists or single `OdooRecord`
+- **Iteration, indexing, `len()`, `bool()`** — recordsets support all
+  standard collection operations; empty recordsets are falsy
+- **`.ids`** property — returns a list of integer IDs for all records
+- **`.mapped(field_name)`** — collect field values across all records
+- **`.filtered(func)`** — return a new recordset with matching records
+- **`.sorted(key, reverse)`** — sort by ID, field name, or callable
+- **`.ensure_one()`** — raise `ValueError` if not exactly one record
+- **Singleton field delegation** — access fields directly on single-record
+  recordsets: `partner.name` works when the recordset has exactly one record
+- **Set operations** — `|` (union), `&` (intersection), `-` (difference),
+  `+` (concatenation) on recordsets
+- **Batch `write()` / `unlink()`** on recordsets — single RPC call for all IDs
+- **`sudo()`, `with_user()`, `with_context()`, `refresh()`** on recordsets
 
 ## What's New in Version 0.3.0
 

--- a/pyodoo_connect/__init__.py
+++ b/pyodoo_connect/__init__.py
@@ -13,6 +13,7 @@ from .odoo import (
     connect_model,
     OdooSession,
     OdooModel,
+    OdooRecordset,
     OdooRecord,
     OdooException,
     OdooConnectionError,
@@ -23,4 +24,4 @@ from .odoo import (
 from .tools import Command
 from .http import connect_http
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/pyodoo_connect/odoo.py
+++ b/pyodoo_connect/odoo.py
@@ -1,6 +1,8 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Union, Tuple
 import httpx
 import warnings
+
+_sorted = sorted  # preserve built-in before OdooRecordset.sorted shadows the name
 
 
 # ---------------------------------------------------------------------------
@@ -346,6 +348,263 @@ class OdooRecord:
 
 
 # ---------------------------------------------------------------------------
+# OdooRecordset
+# ---------------------------------------------------------------------------
+
+class OdooRecordset:
+    """
+    An ordered collection of :class:`OdooRecord` objects for the same model.
+
+    Mirrors the Odoo recordset API: supports iteration, indexing, boolean
+    checks (falsy when empty), field delegation on singletons, and common
+    helpers like ``mapped``, ``filtered``, ``sorted``, and ``ensure_one``.
+
+    Obtain a recordset via :class:`OdooModel`::
+
+        partners = env('res.partner').search([('is_company', '=', True)])
+        for p in partners:
+            print(p.name)
+
+        single = env('res.partner').browse(42)
+        print(single.name)  # field delegation on singleton
+    """
+
+    __slots__ = ('_records', '_model', '_session_id', '_url', '_context', '_client')
+
+    def __init__(
+        self,
+        records: Tuple[OdooRecord, ...],
+        model: str,
+        session_id: str,
+        url: str,
+        context: Optional[dict] = None,
+        client: Optional[httpx.Client] = None,
+    ):
+        self._records: tuple = tuple(records)
+        self._model: str = model
+        self._session_id: str = session_id
+        self._url: str = url
+        self._context: dict = context if context is not None else {"lang": "en_US", "tz": "UTC"}
+        self._client: Optional[httpx.Client] = client
+
+    # ------------------------------------------------------------------
+    # Internal helper
+    # ------------------------------------------------------------------
+
+    def _new(self, records) -> 'OdooRecordset':
+        """Build a new recordset from *records*, reusing model metadata."""
+        return OdooRecordset(
+            tuple(records), self._model, self._session_id,
+            self._url, self._context.copy(), self._client,
+        )
+
+    # ------------------------------------------------------------------
+    # Identity / dunder
+    # ------------------------------------------------------------------
+
+    @property
+    def ids(self) -> List[int]:
+        """Return a list of integer database IDs for all records."""
+        return [r._id for r in self._records]
+
+    @property
+    def id(self) -> int:
+        """The database ID of the singleton record. Raises ValueError if not singleton."""
+        self.ensure_one()
+        return self._records[0]._id
+
+    def __iter__(self):
+        """Iterate over records in the set."""
+        return iter(self._records)
+
+    def __len__(self) -> int:
+        """Return the number of records."""
+        return len(self._records)
+
+    def __bool__(self) -> bool:
+        """True if the recordset is non-empty."""
+        return len(self._records) > 0
+
+    def __getitem__(self, index):
+        """Integer index returns an OdooRecord, slice returns a new OdooRecordset."""
+        if isinstance(index, slice):
+            return self._new(self._records[index])
+        return self._records[index]
+
+    def __contains__(self, item) -> bool:
+        """Check if a record is in the set."""
+        return item in self._records
+
+    def __repr__(self) -> str:
+        ids_str = ", ".join(str(r._id) for r in self._records)
+        return f"{self._model}({ids_str})"
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def __eq__(self, other) -> bool:
+        if isinstance(other, OdooRecordset):
+            return self._model == other._model and self._records == other._records
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash((self._model, self._records))
+
+    # ------------------------------------------------------------------
+    # Singleton field / method delegation
+    # ------------------------------------------------------------------
+
+    def __getattr__(self, name: str):
+        """
+        For singleton recordsets, delegate attribute access to the single record.
+        For multi-record or empty recordsets, raise ValueError.
+        """
+        if name.startswith('_'):
+            raise AttributeError(name)
+        if len(self._records) == 1:
+            return getattr(self._records[0], name)
+        raise ValueError(
+            f"Expected singleton: {self._model} recordset contains "
+            f"{len(self._records)} records"
+        )
+
+    # ------------------------------------------------------------------
+    # Recordset helpers
+    # ------------------------------------------------------------------
+
+    def mapped(self, field_name: str) -> list:
+        """
+        Return a list of field values for the given *field_name* across all records.
+
+        Uses the internal ``_get_field`` method for consistency with lazy caching.
+        """
+        return [record._get_field(field_name) for record in self._records]
+
+    def filtered(self, func) -> 'OdooRecordset':
+        """
+        Return a new recordset containing only records for which *func(record)*
+        is truthy.
+        """
+        return self._new(r for r in self._records if func(r))
+
+    def sorted(self, key=None, reverse: bool = False) -> 'OdooRecordset':
+        """
+        Return a new recordset sorted by *key*.
+
+        If *key* is ``None``, records are sorted by database ID.
+        If *key* is a string, it is treated as a field name.
+        If *key* is callable, it receives each record.
+        """
+        if key is None:
+            sort_key = lambda r: r._id
+        elif isinstance(key, str):
+            field_name = key
+            sort_key = lambda r: r._get_field(field_name)
+        else:
+            sort_key = key
+        return self._new(_sorted(self._records, key=sort_key, reverse=reverse))
+
+    def ensure_one(self) -> 'OdooRecordset':
+        """
+        Raise :class:`ValueError` if this recordset does not contain exactly
+        one record.  Returns ``self`` for chaining.
+        """
+        if len(self._records) != 1:
+            raise ValueError(
+                f"Expected singleton: {self._model} recordset contains "
+                f"{len(self._records)} records"
+            )
+        return self
+
+    # ------------------------------------------------------------------
+    # Batch CRUD
+    # ------------------------------------------------------------------
+
+    def write(self, values: Dict) -> bool:
+        """Write *values* to all records in the set in a single RPC call."""
+        if not self._records:
+            return True
+        ids = self.ids
+        result = self._records[0]._make_request("write", [ids, values])
+        for record in self._records:
+            record._cache.clear()
+        return bool(result)
+
+    def unlink(self) -> bool:
+        """Delete all records in the set in a single RPC call."""
+        if not self._records:
+            return True
+        ids = self.ids
+        return bool(self._records[0]._make_request("unlink", [ids]))
+
+    # ------------------------------------------------------------------
+    # Set operations
+    # ------------------------------------------------------------------
+
+    def __add__(self, other: 'OdooRecordset') -> 'OdooRecordset':
+        """Concatenation (preserves order, may contain duplicates)."""
+        if not isinstance(other, OdooRecordset):
+            return NotImplemented
+        return self._new(self._records + other._records)
+
+    def __or__(self, other: 'OdooRecordset') -> 'OdooRecordset':
+        """Union (preserves order, removes duplicates)."""
+        if not isinstance(other, OdooRecordset):
+            return NotImplemented
+        seen: set = set()
+        result: list = []
+        for r in self._records + other._records:
+            key = (r._model, r._id)
+            if key not in seen:
+                seen.add(key)
+                result.append(r)
+        return self._new(result)
+
+    def __sub__(self, other: 'OdooRecordset') -> 'OdooRecordset':
+        """Difference (records in self but not in other)."""
+        if not isinstance(other, OdooRecordset):
+            return NotImplemented
+        other_keys = {(r._model, r._id) for r in other._records}
+        return self._new(r for r in self._records if (r._model, r._id) not in other_keys)
+
+    def __and__(self, other: 'OdooRecordset') -> 'OdooRecordset':
+        """Intersection (records in both self and other, order from self)."""
+        if not isinstance(other, OdooRecordset):
+            return NotImplemented
+        other_keys = {(r._model, r._id) for r in other._records}
+        return self._new(r for r in self._records if (r._model, r._id) in other_keys)
+
+    # ------------------------------------------------------------------
+    # Context / user modifiers
+    # ------------------------------------------------------------------
+
+    def sudo(self) -> 'OdooRecordset':
+        """Return a new recordset with sudo-modified records."""
+        return self._new(r.sudo() for r in self._records)
+
+    def with_user(self, user_id: int) -> 'OdooRecordset':
+        """Return a new recordset with user-modified records."""
+        return self._new(r.with_user(user_id) for r in self._records)
+
+    def with_context(self, *args, **kwargs) -> 'OdooRecordset':
+        """Return a new recordset with context-modified records."""
+        new_records = tuple(r.with_context(*args, **kwargs) for r in self._records)
+        context = self._context.copy()
+        if args and isinstance(args[0], dict):
+            context.update(args[0])
+        context.update(kwargs)
+        return OdooRecordset(
+            new_records, self._model, self._session_id,
+            self._url, context, self._client,
+        )
+
+    def refresh(self) -> None:
+        """Invalidate the local field cache on all records."""
+        for record in self._records:
+            record.refresh()
+
+
+# ---------------------------------------------------------------------------
 # OdooModel
 # ---------------------------------------------------------------------------
 
@@ -443,6 +702,14 @@ class OdooModel:
             record_id, self._context.copy(), self._client,
         )
 
+    def _make_recordset(self, record_ids: List[int]) -> OdooRecordset:
+        """Construct an :class:`OdooRecordset` from a list of IDs."""
+        records = tuple(self._make_record(rid) for rid in record_ids)
+        return OdooRecordset(
+            records, self._model, self._session_id,
+            self._url, self._context.copy(), self._client,
+        )
+
     # ------------------------------------------------------------------
     # Standard model methods
     # ------------------------------------------------------------------
@@ -453,8 +720,8 @@ class OdooModel:
         limit: Optional[int] = None,
         offset: int = 0,
         order: Optional[str] = None,
-    ) -> List[OdooRecord]:
-        """Search for records and return a list of :class:`OdooRecord` objects."""
+    ) -> OdooRecordset:
+        """Search for records and return an :class:`OdooRecordset`."""
         kw: Dict = {'offset': offset}
         if limit is not None:
             kw['limit'] = limit
@@ -462,8 +729,8 @@ class OdooModel:
             kw['order'] = order
         result = self._make_request("search", [domain or []], kw)
         if not result:
-            return []
-        return [self._make_record(rid) for rid in result]
+            return self._make_recordset([])
+        return self._make_recordset(result)
 
     def search_read(
         self,
@@ -487,11 +754,11 @@ class OdooModel:
         """Return the number of records matching *domain*."""
         return self._make_request("search_count", [domain or []]) or 0
 
-    def create(self, values: Dict) -> OdooRecord:
-        """Create a new record and return an :class:`OdooRecord` for it."""
+    def create(self, values: Dict) -> OdooRecordset:
+        """Create a new record and return an :class:`OdooRecordset` for it."""
         result = self._make_request("create", [values])
         if result:
-            return self._make_record(result)
+            return self._make_recordset([result])
         raise OdooValidationError("Create operation returned no ID")
 
     def write(self, ids: Union[int, List[int]], values: Dict) -> bool:
@@ -519,11 +786,11 @@ class OdooModel:
             kw['fields'] = fields
         return self._make_request("read", [ids], kw) or []
 
-    def browse(self, ids: Union[int, List[int]]) -> Union[OdooRecord, List[OdooRecord]]:
-        """Return an :class:`OdooRecord` (or list thereof) for the given *ids*."""
+    def browse(self, ids: Union[int, List[int]]) -> OdooRecordset:
+        """Return an :class:`OdooRecordset` for the given *ids*."""
         if isinstance(ids, int):
-            return self._make_record(ids)
-        return [self._make_record(rid) for rid in ids]
+            return self._make_recordset([ids])
+        return self._make_recordset(ids)
 
     # ------------------------------------------------------------------
     # Context / user modifiers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyodoo_connect"
-version = "0.3.0"
+version = "0.3.1"
 description = "A Python package to interact with Odoo via JSON-RPC."
 authors = [{ name = "Fasil", email = "fasilwdr@hotmail.com" }]
 license = { file = "LICENSE" }

--- a/tests/test_odoo.py
+++ b/tests/test_odoo.py
@@ -7,7 +7,7 @@
 # Instagram: https://www.instagram.com/fasilwdr
 #############################################################################
 """
-Mock-based unit tests for pyodoo_connect v0.3.0.
+Mock-based unit tests for pyodoo_connect v0.3.1.
 No live Odoo server is required.
 """
 import pytest
@@ -18,6 +18,7 @@ from pyodoo_connect import (
     connect_model,
     OdooSession,
     OdooModel,
+    OdooRecordset,
     OdooRecord,
     Command,
     OdooException,
@@ -255,9 +256,10 @@ class TestOdooSession:
 
 class TestOdooModelSearch:
 
-    def test_search_returns_list_of_records(self, mock_http_client, partner_model):
+    def test_search_returns_recordset(self, mock_http_client, partner_model):
         mock_http_client.post.return_value = _mock_response(result=[1, 2, 3])
         records = partner_model.search([("is_company", "=", True)])
+        assert isinstance(records, OdooRecordset)
         assert len(records) == 3
         assert all(isinstance(r, OdooRecord) for r in records)
 
@@ -270,12 +272,16 @@ class TestOdooModelSearch:
     def test_search_empty_result(self, mock_http_client, partner_model):
         mock_http_client.post.return_value = _mock_response(result=[])
         records = partner_model.search([("name", "=", "Nobody")])
-        assert records == []
+        assert isinstance(records, OdooRecordset)
+        assert len(records) == 0
+        assert not records
 
     def test_search_false_result(self, mock_http_client, partner_model):
         mock_http_client.post.return_value = _mock_response(result=False)
         records = partner_model.search([])
-        assert records == []
+        assert isinstance(records, OdooRecordset)
+        assert len(records) == 0
+        assert not records
 
     def test_search_with_limit(self, mock_http_client, partner_model):
         mock_http_client.post.return_value = _mock_response(result=[1, 2])
@@ -355,11 +361,13 @@ class TestOdooModelSearchCount:
 
 class TestOdooModelCreate:
 
-    def test_returns_record(self, mock_http_client, partner_model):
+    def test_returns_recordset(self, mock_http_client, partner_model):
         mock_http_client.post.return_value = _mock_response(result=99)
         record = partner_model.create({"name": "New Partner"})
-        assert isinstance(record, OdooRecord)
+        assert isinstance(record, OdooRecordset)
+        assert len(record) == 1
         assert record.id == 99
+        assert record.ids == [99]
 
     def test_create_validation_error_on_false(self, mock_http_client, partner_model):
         mock_http_client.post.return_value = _mock_response(result=False)
@@ -437,17 +445,21 @@ class TestOdooModelBrowse:
 
     def test_browse_single_int(self, partner_model):
         record = partner_model.browse(7)
-        assert isinstance(record, OdooRecord)
+        assert isinstance(record, OdooRecordset)
+        assert len(record) == 1
         assert record.id == 7
+        assert record.ids == [7]
 
     def test_browse_list(self, partner_model):
         records = partner_model.browse([1, 2, 3])
+        assert isinstance(records, OdooRecordset)
         assert len(records) == 3
+        assert records.ids == [1, 2, 3]
         assert [r.id for r in records] == [1, 2, 3]
 
     def test_browse_shares_client(self, session, partner_model):
         record = partner_model.browse(1)
-        assert record._client is session._client
+        assert record[0]._client is session._client
 
 
 # ===========================================================================
@@ -1160,6 +1172,450 @@ class TestRequestHeaders:
         partner_model.search([])
         called_url = mock_http_client.post.call_args[0][0]
         assert "/web/dataset/call_kw/res.partner/search" in called_url
+
+
+# ===========================================================================
+# OdooRecordset – core behaviour
+# ===========================================================================
+
+@pytest.fixture
+def partner_recordset(session):
+    """Return a 3-record OdooRecordset backed by the mock client."""
+    records = tuple(
+        OdooRecord(
+            session_id="test_session_123",
+            url="https://test.odoo.com",
+            model="res.partner",
+            record_id=rid,
+            context={"lang": "en_US", "tz": "UTC"},
+            client=session._client,
+        )
+        for rid in [1, 2, 3]
+    )
+    return OdooRecordset(
+        records, "res.partner", "test_session_123",
+        "https://test.odoo.com", {"lang": "en_US", "tz": "UTC"},
+        session._client,
+    )
+
+
+@pytest.fixture
+def empty_recordset(session):
+    """Return an empty OdooRecordset."""
+    return OdooRecordset(
+        (), "res.partner", "test_session_123",
+        "https://test.odoo.com", {"lang": "en_US", "tz": "UTC"},
+        session._client,
+    )
+
+
+@pytest.fixture
+def singleton_recordset(session):
+    """Return a single-record OdooRecordset."""
+    record = OdooRecord(
+        session_id="test_session_123",
+        url="https://test.odoo.com",
+        model="res.partner",
+        record_id=42,
+        context={"lang": "en_US", "tz": "UTC"},
+        client=session._client,
+    )
+    return OdooRecordset(
+        (record,), "res.partner", "test_session_123",
+        "https://test.odoo.com", {"lang": "en_US", "tz": "UTC"},
+        session._client,
+    )
+
+
+class TestOdooRecordsetCore:
+
+    def test_len(self, partner_recordset):
+        assert len(partner_recordset) == 3
+
+    def test_bool_true(self, partner_recordset):
+        assert bool(partner_recordset) is True
+
+    def test_bool_false_empty(self, empty_recordset):
+        assert bool(empty_recordset) is False
+
+    def test_iter(self, partner_recordset):
+        items = list(partner_recordset)
+        assert len(items) == 3
+        assert all(isinstance(r, OdooRecord) for r in items)
+
+    def test_getitem_int(self, partner_recordset):
+        r = partner_recordset[0]
+        assert isinstance(r, OdooRecord)
+        assert r.id == 1
+
+    def test_getitem_negative_index(self, partner_recordset):
+        assert partner_recordset[-1].id == 3
+
+    def test_getitem_slice(self, partner_recordset):
+        sliced = partner_recordset[0:2]
+        assert isinstance(sliced, OdooRecordset)
+        assert len(sliced) == 2
+        assert sliced.ids == [1, 2]
+
+    def test_contains(self, partner_recordset):
+        r = partner_recordset[0]
+        assert r in partner_recordset
+
+    def test_repr(self, partner_recordset):
+        assert repr(partner_recordset) == "res.partner(1, 2, 3)"
+
+    def test_repr_empty(self, empty_recordset):
+        assert repr(empty_recordset) == "res.partner()"
+
+    def test_repr_singleton(self, singleton_recordset):
+        assert repr(singleton_recordset) == "res.partner(42)"
+
+    def test_str(self, partner_recordset):
+        assert str(partner_recordset) == "res.partner(1, 2, 3)"
+
+    def test_eq(self, session):
+        rs1 = OdooRecordset(
+            tuple(OdooRecord("sid", "url", "res.partner", i, client=session._client) for i in [1, 2]),
+            "res.partner", "sid", "url", client=session._client,
+        )
+        rs2 = OdooRecordset(
+            tuple(OdooRecord("sid", "url", "res.partner", i, client=session._client) for i in [1, 2]),
+            "res.partner", "sid", "url", client=session._client,
+        )
+        assert rs1 == rs2
+
+    def test_neq_different_records(self, session):
+        rs1 = OdooRecordset(
+            tuple(OdooRecord("sid", "url", "res.partner", i, client=session._client) for i in [1, 2]),
+            "res.partner", "sid", "url", client=session._client,
+        )
+        rs2 = OdooRecordset(
+            tuple(OdooRecord("sid", "url", "res.partner", i, client=session._client) for i in [1, 3]),
+            "res.partner", "sid", "url", client=session._client,
+        )
+        assert rs1 != rs2
+
+    def test_hash(self, session):
+        rs1 = OdooRecordset(
+            tuple(OdooRecord("sid", "url", "res.partner", i, client=session._client) for i in [1, 2]),
+            "res.partner", "sid", "url", client=session._client,
+        )
+        rs2 = OdooRecordset(
+            tuple(OdooRecord("sid", "url", "res.partner", i, client=session._client) for i in [1, 2]),
+            "res.partner", "sid", "url", client=session._client,
+        )
+        assert hash(rs1) == hash(rs2)
+
+    def test_ids(self, partner_recordset):
+        assert partner_recordset.ids == [1, 2, 3]
+
+    def test_ids_empty(self, empty_recordset):
+        assert empty_recordset.ids == []
+
+    def test_id_singleton(self, singleton_recordset):
+        assert singleton_recordset.id == 42
+
+    def test_id_multi_raises(self, partner_recordset):
+        with pytest.raises(ValueError, match="Expected singleton"):
+            _ = partner_recordset.id
+
+    def test_id_empty_raises(self, empty_recordset):
+        with pytest.raises(ValueError, match="Expected singleton"):
+            _ = empty_recordset.id
+
+
+# ===========================================================================
+# OdooRecordset – singleton field delegation
+# ===========================================================================
+
+class TestOdooRecordsetFieldDelegation:
+
+    def test_singleton_field_access(self, mock_http_client, singleton_recordset):
+        mock_http_client.post.return_value = _mock_response(
+            result=[{"id": 42, "name": "John Doe"}]
+        )
+        assert str(singleton_recordset.name) == "John Doe"
+
+    def test_singleton_field_eq(self, mock_http_client, singleton_recordset):
+        mock_http_client.post.return_value = _mock_response(
+            result=[{"id": 42, "name": "Alice"}]
+        )
+        assert singleton_recordset.name == "Alice"
+
+    def test_singleton_method_call(self, mock_http_client, singleton_recordset):
+        mock_http_client.post.return_value = _mock_response(result=True)
+        result = singleton_recordset.action_confirm()
+        assert result is True
+        payload = mock_http_client.post.call_args[1]["json"]
+        assert payload["params"]["method"] == "action_confirm"
+
+    def test_multi_record_field_raises(self, partner_recordset):
+        with pytest.raises(ValueError, match="Expected singleton"):
+            _ = partner_recordset.name
+
+    def test_empty_field_raises(self, empty_recordset):
+        with pytest.raises(ValueError, match="Expected singleton"):
+            _ = empty_recordset.name
+
+    def test_private_attr_raises_attribute_error(self, singleton_recordset):
+        with pytest.raises(AttributeError):
+            _ = singleton_recordset._something
+
+
+# ===========================================================================
+# OdooRecordset – mapped
+# ===========================================================================
+
+class TestOdooRecordsetMapped:
+
+    def test_mapped_returns_field_values(self, mock_http_client, partner_recordset):
+        # Each record will make a separate _get_field call
+        mock_http_client.post.side_effect = [
+            _mock_response(result=[{"id": 1, "name": "Alice"}]),
+            _mock_response(result=[{"id": 2, "name": "Bob"}]),
+            _mock_response(result=[{"id": 3, "name": "Charlie"}]),
+        ]
+        names = partner_recordset.mapped("name")
+        assert names == ["Alice", "Bob", "Charlie"]
+
+    def test_mapped_empty(self, empty_recordset):
+        assert empty_recordset.mapped("name") == []
+
+
+# ===========================================================================
+# OdooRecordset – filtered
+# ===========================================================================
+
+class TestOdooRecordsetFiltered:
+
+    def test_filtered_by_callable(self, partner_recordset):
+        result = partner_recordset.filtered(lambda r: r.id > 1)
+        assert isinstance(result, OdooRecordset)
+        assert result.ids == [2, 3]
+
+    def test_filtered_empty_result(self, partner_recordset):
+        result = partner_recordset.filtered(lambda r: r.id > 100)
+        assert len(result) == 0
+        assert not result
+
+
+# ===========================================================================
+# OdooRecordset – sorted
+# ===========================================================================
+
+class TestOdooRecordsetSorted:
+
+    def test_sorted_default_by_id(self, session):
+        records = tuple(
+            OdooRecord("sid", "url", "res.partner", i, client=session._client)
+            for i in [3, 1, 2]
+        )
+        rs = OdooRecordset(records, "res.partner", "sid", "url", client=session._client)
+        result = rs.sorted()
+        assert result.ids == [1, 2, 3]
+
+    def test_sorted_reverse(self, partner_recordset):
+        result = partner_recordset.sorted(reverse=True)
+        assert result.ids == [3, 2, 1]
+
+    def test_sorted_by_callable(self, partner_recordset):
+        result = partner_recordset.sorted(key=lambda r: -r.id)
+        assert result.ids == [3, 2, 1]
+
+    def test_sorted_returns_recordset(self, partner_recordset):
+        assert isinstance(partner_recordset.sorted(), OdooRecordset)
+
+
+# ===========================================================================
+# OdooRecordset – ensure_one
+# ===========================================================================
+
+class TestOdooRecordsetEnsureOne:
+
+    def test_singleton_returns_self(self, singleton_recordset):
+        result = singleton_recordset.ensure_one()
+        assert result is singleton_recordset
+
+    def test_empty_raises(self, empty_recordset):
+        with pytest.raises(ValueError, match="Expected singleton"):
+            empty_recordset.ensure_one()
+
+    def test_multi_raises(self, partner_recordset):
+        with pytest.raises(ValueError, match="Expected singleton"):
+            partner_recordset.ensure_one()
+
+    def test_error_message_contains_count(self, partner_recordset):
+        with pytest.raises(ValueError, match="3 records"):
+            partner_recordset.ensure_one()
+
+
+# ===========================================================================
+# OdooRecordset – batch write / unlink
+# ===========================================================================
+
+class TestOdooRecordsetBatchWrite:
+
+    def test_write_single_rpc(self, mock_http_client, partner_recordset):
+        mock_http_client.post.return_value = _mock_response(result=True)
+        assert partner_recordset.write({"active": False}) is True
+        payload = mock_http_client.post.call_args[1]["json"]
+        assert payload["params"]["args"][0] == [1, 2, 3]
+
+    def test_write_clears_all_caches(self, mock_http_client, partner_recordset):
+        for r in partner_recordset:
+            r._cache["name"] = "old"
+        mock_http_client.post.return_value = _mock_response(result=True)
+        partner_recordset.write({"name": "new"})
+        for r in partner_recordset:
+            assert "name" not in r._cache
+
+    def test_write_empty_no_rpc(self, mock_http_client, empty_recordset):
+        assert empty_recordset.write({"name": "x"}) is True
+        mock_http_client.post.assert_not_called()
+
+
+class TestOdooRecordsetBatchUnlink:
+
+    def test_unlink_single_rpc(self, mock_http_client, partner_recordset):
+        mock_http_client.post.return_value = _mock_response(result=True)
+        assert partner_recordset.unlink() is True
+        payload = mock_http_client.post.call_args[1]["json"]
+        assert payload["params"]["args"][0] == [1, 2, 3]
+
+    def test_unlink_empty_no_rpc(self, mock_http_client, empty_recordset):
+        assert empty_recordset.unlink() is True
+        mock_http_client.post.assert_not_called()
+
+
+# ===========================================================================
+# OdooRecordset – set operations
+# ===========================================================================
+
+class TestOdooRecordsetSetOperations:
+
+    def test_add_concatenates(self, session):
+        rs1 = OdooRecordset(
+            tuple(OdooRecord("sid", "url", "res.partner", i, client=session._client) for i in [1, 2]),
+            "res.partner", "sid", "url", client=session._client,
+        )
+        rs2 = OdooRecordset(
+            tuple(OdooRecord("sid", "url", "res.partner", i, client=session._client) for i in [2, 3]),
+            "res.partner", "sid", "url", client=session._client,
+        )
+        result = rs1 + rs2
+        assert isinstance(result, OdooRecordset)
+        assert result.ids == [1, 2, 2, 3]
+
+    def test_or_deduplicates(self, session):
+        rs1 = OdooRecordset(
+            tuple(OdooRecord("sid", "url", "res.partner", i, client=session._client) for i in [1, 2]),
+            "res.partner", "sid", "url", client=session._client,
+        )
+        rs2 = OdooRecordset(
+            tuple(OdooRecord("sid", "url", "res.partner", i, client=session._client) for i in [2, 3]),
+            "res.partner", "sid", "url", client=session._client,
+        )
+        result = rs1 | rs2
+        assert result.ids == [1, 2, 3]
+
+    def test_sub_removes(self, session):
+        rs1 = OdooRecordset(
+            tuple(OdooRecord("sid", "url", "res.partner", i, client=session._client) for i in [1, 2, 3]),
+            "res.partner", "sid", "url", client=session._client,
+        )
+        rs2 = OdooRecordset(
+            tuple(OdooRecord("sid", "url", "res.partner", i, client=session._client) for i in [2]),
+            "res.partner", "sid", "url", client=session._client,
+        )
+        result = rs1 - rs2
+        assert result.ids == [1, 3]
+
+    def test_and_intersects(self, session):
+        rs1 = OdooRecordset(
+            tuple(OdooRecord("sid", "url", "res.partner", i, client=session._client) for i in [1, 2, 3]),
+            "res.partner", "sid", "url", client=session._client,
+        )
+        rs2 = OdooRecordset(
+            tuple(OdooRecord("sid", "url", "res.partner", i, client=session._client) for i in [2, 3, 4]),
+            "res.partner", "sid", "url", client=session._client,
+        )
+        result = rs1 & rs2
+        assert result.ids == [2, 3]
+
+    def test_add_with_non_recordset_returns_not_implemented(self, partner_recordset):
+        result = partner_recordset.__add__(5)
+        assert result is NotImplemented
+
+
+# ===========================================================================
+# OdooRecordset – context modifiers
+# ===========================================================================
+
+class TestOdooRecordsetModifiers:
+
+    def test_sudo_returns_recordset(self, partner_recordset):
+        result = partner_recordset.sudo()
+        assert isinstance(result, OdooRecordset)
+        assert result.ids == partner_recordset.ids
+
+    def test_with_user_returns_recordset(self, partner_recordset):
+        result = partner_recordset.with_user(3)
+        assert isinstance(result, OdooRecordset)
+        assert result.ids == partner_recordset.ids
+
+    def test_with_context_updates(self, partner_recordset):
+        result = partner_recordset.with_context(lang="fr_FR")
+        assert result._context["lang"] == "fr_FR"
+
+    def test_refresh_clears_all_caches(self, partner_recordset):
+        for r in partner_recordset:
+            r._cache["name"] = "cached"
+        partner_recordset.refresh()
+        for r in partner_recordset:
+            assert "name" not in r._cache
+
+
+# ===========================================================================
+# OdooRecordset – integration with OdooModel
+# ===========================================================================
+
+class TestOdooRecordsetIntegration:
+    """Test that OdooModel methods correctly return OdooRecordset."""
+
+    def test_search_iteration(self, mock_http_client, partner_model):
+        mock_http_client.post.return_value = _mock_response(result=[10, 20, 30])
+        records = partner_model.search([("is_company", "=", True)])
+        ids = [r.id for r in records]
+        assert ids == [10, 20, 30]
+
+    def test_search_singleton_field_delegation(self, mock_http_client, partner_model):
+        """search with limit=1 returns recordset where field delegation works."""
+        mock_http_client.post.return_value = _mock_response(result=[42])
+        partner = partner_model.search([("name", "=", "John")], limit=1)
+        assert bool(partner)  # truthy when non-empty
+        mock_http_client.post.return_value = _mock_response(
+            result=[{"id": 42, "name": "John"}]
+        )
+        assert partner.name == "John"  # field delegation on singleton
+
+    def test_search_empty_is_falsy(self, mock_http_client, partner_model):
+        mock_http_client.post.return_value = _mock_response(result=[])
+        records = partner_model.search([("name", "=", "Nobody")])
+        assert not records
+        assert len(records) == 0
+
+    def test_browse_list_ids(self, mock_http_client, partner_model):
+        partners = partner_model.browse([1, 2, 3])
+        assert partners.ids == [1, 2, 3]
+
+    def test_browse_list_mapped(self, mock_http_client, partner_model):
+        partners = partner_model.browse([10, 20])
+        mock_http_client.post.side_effect = [
+            _mock_response(result=[{"id": 10, "name": "Alpha"}]),
+            _mock_response(result=[{"id": 20, "name": "Beta"}]),
+        ]
+        names = partners.mapped("name")
+        assert names == ["Alpha", "Beta"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### New: `OdooRecordset` class (`pyodoo_connect/odoo.py`)
- Wraps a tuple of `OdooRecord` objects with Odoo-native recordset behavior
- **Core**: `__iter__`, `__len__`, `__bool__` (falsy when empty), `__getitem__` (int→record, slice→recordset), `__contains__`, `__repr__`, `__eq__`, `__hash__`
- **Properties**: `.ids` (all IDs), `.id` (singleton only)
- **Helpers**: `mapped()`, `filtered()`, `sorted()`, `ensure_one()`
- **Singleton delegation**: `recordset.name` delegates to the single record's field when len==1
- **Set ops**: `+` (concat), `|` (union), `-` (difference), `&` (intersection)
- **Batch CRUD**: `write()` and `unlink()` make single RPC calls with all IDs
- **Modifiers**: `sudo()`, `with_user()`, `with_context()`, `refresh()`

### Modified: `OdooModel` return types
- `search()` → returns `OdooRecordset` (was `List[OdooRecord]`)
- `browse(int/list)` → always returns `OdooRecordset` (was `OdooRecord`/`List[OdooRecord]`)
- `create()` → returns `OdooRecordset` (was `OdooRecord`)

### Version bumped to 0.3.1
- `__init__.py`, `pyproject.toml`

### Tests: 214 tests, all passing
- Updated 6 existing tests for new return types
- Added 60 new tests across 10 test classes for OdooRecordset

All your expected scenarios now work:
```python
partners = env('res.partner').search([('is_company', '=', True)])
for p in partners: print(p.name)

partner = env('res.partner').search([('name', '=', 'John')], limit=1)
if partner: print(partner.name)

partners = env('res.partner').browse([1, 2, 3])
print(partners.ids)              # [1, 2, 3]
print(partners.mapped("name"))   # ['Alice', 'Bob', 'Charlie']
```